### PR TITLE
Allow dependency updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,18 +3,12 @@
   "description": "A client for Innovative's Sierra APIs",
   "type": "library",
   "require": {
-    "guzzlehttp/guzzle": "6.2.3",
+    "guzzlehttp/guzzle": "^6.2.3",
     "kamermans/guzzle-oauth2-subscriber": "^1.0"
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/timhodson/php-split-timer"
-    }
-  ],
   "require-dev": {
-    "phpunit/phpunit": "4.1.6",
-    "squizlabs/php_codesniffer": "3.*"
+    "phpunit/phpunit": "^4.8.36",
+    "squizlabs/php_codesniffer": "^3.7.2"
   },
   "license": "MIT",
   "authors": [

--- a/src/Sierra/Version.php
+++ b/src/Sierra/Version.php
@@ -4,5 +4,5 @@ namespace Sierra;
 
 class Version
 {
-    const VERSION='0.1.0';
+    const VERSION='0.2.0';
 }


### PR DESCRIPTION
* Allow any semantic version of `guzzlehttp/guzzle` (>= 6.2.3, <7.0.0)
* Update semantic versions of other packages.
* Remove php-split-timer repo, it's not used here.
* Bump the version.